### PR TITLE
Better Swift compatibility for status codes

### DIFF
--- a/HTTPStatusCodes.h
+++ b/HTTPStatusCodes.h
@@ -4,7 +4,7 @@
 
 // Based on http://en.wikipedia.org/wiki/Http_status_codes
 
-enum HTTPStatusCodes {
+typedef NS_ENUM(NSInteger, kHTTPStatusCode) {
 #pragma mark 1xx Informational
     kHTTPStatusCodeContinue = 100,
     kHTTPStatusCodeSwitchingProtocols = 101,

--- a/HTTPStatusCodes.h
+++ b/HTTPStatusCodes.h
@@ -4,7 +4,7 @@
 
 // Based on http://en.wikipedia.org/wiki/Http_status_codes
 
-typedef NS_ENUM(NSInteger, kHTTPStatusCode) {
+typedef NS_ENUM(NSInteger, HTTPStatusCode) {
 #pragma mark 1xx Informational
     kHTTPStatusCodeContinue = 100,
     kHTTPStatusCodeSwitchingProtocols = 101,

--- a/ILGHttpConstants.podspec
+++ b/ILGHttpConstants.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ILGHttpConstants"
-  s.version      = "1.0.1"
+  s.version      = "2.0.0"
   s.summary      = "Constants for HTTP status codes, headers, and method names."
   s.homepage     = "https://github.com/ilg/ILGHttpConstants"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ILGHttpConstants
 
-For Objective-C.  MIT License (to whatever extent anything in this library is copyrightable—for the most part, it probably isn't).
+For Objective-C and Swift.  MIT License (to whatever extent anything in this library is copyrightable—for the most part, it probably isn't).
 
 ## HTTPStatusCodes.h
 


### PR DESCRIPTION
Swapped the existing enum to `NS_ENUM` for considerably better Swift compatibility. Now things will automagically show up as `Int`s instead of some nonsense with `Int32`, and you can use the failable `Int` initializer for stuff like: 

```swift
guard let statusCode = HTTPStatusCode(rawValue: 404) else {
    print("not an actual status code"
    return
}

switch statusCode {
case .notFound: // or .NotFound in Swift 2.3
   print("404!")
default:
   print("Something else went wrong")
}
```

Bumped podspec to 2.0 despite the minute number of changes since this would break existing swift code. 